### PR TITLE
Remove default voice from the interface

### DIFF
--- a/tests/test_voice_ui.py
+++ b/tests/test_voice_ui.py
@@ -281,6 +281,7 @@ class TestVoiceUI(unittest.TestCase):
         self.voice_ui._speaker_queue.get = MagicMock(
             side_effect=speaker_queue_get_side_effect
         )
+        self.voice_ui._speaker_queue.task_done = MagicMock()
 
         self.voice_ui._text_to_speech_thread_function()
 
@@ -291,6 +292,8 @@ class TestVoiceUI(unittest.TestCase):
             ]
         )
         self.assertTrue(mock_logging_error.called)
+
+        self.voice_ui._speaker_queue.task_done.assert_has_calls([call(), call()])
 
     def test_speak(self):
         text = "Hello world"

--- a/voice_ui/config.py
+++ b/voice_ui/config.py
@@ -55,10 +55,6 @@ class VoiceUIConfig:
             Supported values: 'openai-tts', 'google', 'passthrough'
             Default: 'openai-tts'
 
-        voice_name: Voice identifier/name for TTS output.
-            Available voices depend on the TTS engine selected.
-            Default: None (uses engine default)
-
         hotword_inactivity_timeout: Seconds of inactivity before automatically
             switching back to hotword detection mode. If None, inactivity timeout
             is disabled.
@@ -74,7 +70,6 @@ class VoiceUIConfig:
     additional_keyword_paths: Dict[str, str] = field(default_factory=dict)
     audio_transcriber: str = "whisper"
     tts_engine: str = "openai-tts"
-    voice_name: Optional[str] = None
     hotword_inactivity_timeout: Optional[float] = None
 
     def __post_init__(self):

--- a/voice_ui/voice_ui.py
+++ b/voice_ui/voice_ui.py
@@ -286,11 +286,24 @@ class VoiceUI:
             try:
                 item = self._speaker_queue.get(timeout=1)
 
-                try:
-                    (text, tts_kwargs) = item
-                except (ValueError, TypeError) as e:
-                    logger.error(f"Invalid queue item for TTS: {item!r}, error: {e}")
-                    continue
+                if isinstance(item, str):
+                    text, tts_kwargs = item, {}
+                else:
+                    try:
+                        (text, tts_kwargs) = item
+                    except (ValueError, TypeError) as e:
+                        logger.error(
+                            f"Invalid queue item for TTS: {item!r}, error: {e}"
+                        )
+                        continue
+
+                    if tts_kwargs is None:
+                        tts_kwargs = {}
+                    elif not isinstance(tts_kwargs, dict):
+                        logger.error(
+                            f"Invalid TTS kwargs type: {type(tts_kwargs)!r} for item: {item!r}"
+                        )
+                        continue
 
                 # if not self._voice_output_enabled:
                 #     continue

--- a/voice_ui/voice_ui.py
+++ b/voice_ui/voice_ui.py
@@ -283,14 +283,14 @@ class VoiceUI:
     def _text_to_speech_thread_function(self):
         while not self._terminated:
             try:
-                text = self._speaker_queue.get(timeout=1)
+                (text, kwargs) = self._speaker_queue.get(timeout=1)
 
                 # if not self._voice_output_enabled:
                 #     continue
 
                 self._tts_streamer.speak(
-                    text=text,
-                    voice=self._config.voice_name,
+                    text,
+                    **kwargs,
                 )
                 self._speaker_queue.task_done()
 
@@ -299,16 +299,16 @@ class VoiceUI:
             except Exception as e:
                 logger.error(f"Error while transcribing text: {e}")
 
-    def speak(self, text: str, wait: bool = False):
+    def speak(self, text: str, wait: bool = False, **kwargs):
         if wait:
             self._tts_streamer.speak(
-                text=text,
-                voice=self._config.voice_name,
+                text,
+                **kwargs,
             )
             while self._tts_streamer.is_speaking():
                 time.sleep(timedelta(milliseconds=10).total_seconds())
         else:
-            self._speaker_queue.put(text)
+            self._speaker_queue.put((text, kwargs))
 
     def is_speaking(self) -> bool:
         return self._speaker_queue.qsize() > 0 or self._tts_streamer.is_speaking()


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove `voice_name` parameter from VoiceUIConfig class

- Update TTS interface to accept voice selection via kwargs

- Modify speaker queue to pass text and kwargs tuple

- Update all test cases to reflect new TTS API signature


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VoiceUIConfig"] -->|removed voice_name| B["Config without voice"]
  C["speak method"] -->|accepts kwargs| D["TTS streamer"]
  E["Speaker queue"] -->|passes text + kwargs| F["TTS thread function"]
  F -->|unpacks kwargs| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Remove voice_name field from config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

voice_ui/config.py

<ul><li>Removed <code>voice_name</code> optional field from VoiceUIConfig dataclass<br> <li> Removed documentation for <code>voice_name</code> parameter from docstring<br> <li> Voice selection now handled externally via kwargs instead of config</ul>


</details>


  </td>
  <td><a href="https://github.com/andyluiz/voice-ui/pull/8/files#diff-65d6651b00a56c6a119a3bc5ce566cf6b20e0c084a560d5f2de3737f85868ac0">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>voice_ui.py</strong><dd><code>Update TTS interface to use kwargs for voice</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

voice_ui/voice_ui.py

<ul><li>Modified <code>_text_to_speech_thread_function</code> to unpack text and kwargs <br>tuple from queue<br> <li> Updated <code>speak</code> method to accept <code>**kwargs</code> parameter<br> <li> Changed speaker queue to store tuples of (text, kwargs) instead of <br>just text<br> <li> Removed hardcoded <code>voice_name</code> parameter from TTS streamer calls<br> <li> TTS voice selection now passed dynamically via kwargs</ul>


</details>


  </td>
  <td><a href="https://github.com/andyluiz/voice-ui/pull/8/files#diff-41512f2098720f98e1d19024de65a7ee33ae00d8560ff3a7ac5efc0afdc2b91d">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_voice_ui.py</strong><dd><code>Update tests for new TTS API signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_voice_ui.py

<ul><li>Removed <code>voice_name="test_voice"</code> from all VoiceUIConfig instantiations <br>in tests<br> <li> Updated speaker queue mock returns to use (text, kwargs) tuple format<br> <li> Modified TTS streamer call assertions to match new signature without <br>voice parameter<br> <li> Updated test assertions to use positional arguments instead of named <br>parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/andyluiz/voice-ui/pull/8/files#diff-4d88d87c521285c892dda26408511d32ef9ed71bdda153947567179db003107c">+8/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

